### PR TITLE
bugfix: fixed combinatory.Generate func

### DIFF
--- a/internal/combinatory/generate.go
+++ b/internal/combinatory/generate.go
@@ -20,7 +20,7 @@ func Generate(arr [][]any) [][]any {
 		for _, value := range parameter {
 			// append the value to each combination
 			for _, combination := range result {
-				temp = append(temp, append(combination, value))
+				temp = append(temp, append([]any{}, append(combination, value)...))
 			}
 		}
 		// update result

--- a/internal/combinatory/generate_test.go
+++ b/internal/combinatory/generate_test.go
@@ -1,10 +1,11 @@
 package combinatory_test
 
 import (
-	"github.com/franiglesias/golden/internal/combinatory"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/franiglesias/golden/internal/combinatory"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerate(t *testing.T) {
@@ -43,6 +44,45 @@ func TestGenerate(t *testing.T) {
 				{1, "b", "%"},
 				{2, "b", "%"},
 				{3, "b", "%"},
+			},
+		},
+
+		{
+			name: "should combine 5 parameters with 2 values each",
+			args: [][]any{{"a", "b"}, {"c", "d"}, {"e", "f"}, {"g", "h"}, {"j", "k"}},
+			want: [][]any{
+				{"a", "c", "e", "g", "j"},
+				{"b", "c", "e", "g", "j"},
+				{"a", "d", "e", "g", "j"},
+				{"b", "d", "e", "g", "j"},
+				{"a", "c", "f", "g", "j"},
+				{"b", "c", "f", "g", "j"},
+				{"a", "d", "f", "g", "j"},
+				{"b", "d", "f", "g", "j"},
+				{"a", "c", "e", "h", "j"},
+				{"b", "c", "e", "h", "j"},
+				{"a", "d", "e", "h", "j"},
+				{"b", "d", "e", "h", "j"},
+				{"a", "c", "f", "h", "j"},
+				{"b", "c", "f", "h", "j"},
+				{"a", "d", "f", "h", "j"},
+				{"b", "d", "f", "h", "j"},
+				{"a", "c", "e", "g", "k"},
+				{"b", "c", "e", "g", "k"},
+				{"a", "d", "e", "g", "k"},
+				{"b", "d", "e", "g", "k"},
+				{"a", "c", "f", "g", "k"},
+				{"b", "c", "f", "g", "k"},
+				{"a", "d", "f", "g", "k"},
+				{"b", "d", "f", "g", "k"},
+				{"a", "c", "e", "h", "k"},
+				{"b", "c", "e", "h", "k"},
+				{"a", "d", "e", "h", "k"},
+				{"b", "d", "e", "h", "k"},
+				{"a", "c", "f", "h", "k"},
+				{"b", "c", "f", "h", "k"},
+				{"a", "d", "f", "h", "k"},
+				{"b", "d", "f", "h", "k"},
 			},
 		},
 


### PR DESCRIPTION
Tricky one. Here's playground with some prints for debugging: https://go.dev/play/p/JoJL7tXB3xF
The issue is caused by unintentional reusing of slices.